### PR TITLE
Update dependencies

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -15,7 +15,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [10.x]  # Oldest 'Active' version: https://nodejs.org/en/about/releases/
+        node-version: [12.x, 14.x]  # Oldest 'Active' version: https://nodejs.org/en/about/releases/
 
     steps:
     - uses: actions/checkout@v2

--- a/package-lock.json
+++ b/package-lock.json
@@ -41,7 +41,7 @@
         "@types/object-assign-deep": "^0.4.0",
         "@types/pg": "^7.14.11",
         "@types/request": "^2.48.5",
-        "@types/sharp": "^0.27.3",
+        "@types/sharp": "^0.28.0",
         "@types/superagent": "^4.1.10",
         "cross-env": "^7.0.3",
         "ts-node": "^9.1.1",
@@ -262,9 +262,9 @@
       }
     },
     "node_modules/@types/sharp": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@types/sharp/-/sharp-0.27.3.tgz",
-      "integrity": "sha512-QadrXVVmHBqzDM0hJd7imgra+sXj3iM5TWDuFv/+6AOhA9tubKrt3acjucN5/TdzK8nfmBOX07CRbNC0MLwqog==",
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@types/sharp/-/sharp-0.28.0.tgz",
+      "integrity": "sha512-YvRFnQM44wAihAKzBDzu3BxnEohpqWd/5KXkwsSUl3qFTb51NyKHCKHX1D62YAy0jZij5aXgm/33v/Cv6VVsdA==",
       "dev": true,
       "dependencies": {
         "@types/node": "*"
@@ -3798,9 +3798,9 @@
       }
     },
     "@types/sharp": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@types/sharp/-/sharp-0.27.3.tgz",
-      "integrity": "sha512-QadrXVVmHBqzDM0hJd7imgra+sXj3iM5TWDuFv/+6AOhA9tubKrt3acjucN5/TdzK8nfmBOX07CRbNC0MLwqog==",
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@types/sharp/-/sharp-0.28.0.tgz",
+      "integrity": "sha512-YvRFnQM44wAihAKzBDzu3BxnEohpqWd/5KXkwsSUl3qFTb51NyKHCKHX1D62YAy0jZij5aXgm/33v/Cv6VVsdA==",
       "dev": true,
       "requires": {
         "@types/node": "*"

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,7 +25,7 @@
         "pg": "^8.5.1",
         "request": "^2.88.2",
         "rotating-file-stream": "^2.1.5",
-        "sharp": "^0.28.0",
+        "sharp": "^0.28.1",
         "superagent": "^6.1.0",
         "uuid": "^8.3.2"
       },
@@ -2471,9 +2471,9 @@
       }
     },
     "node_modules/prebuild-install": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-6.0.1.tgz",
-      "integrity": "sha512-7GOJrLuow8yeiyv75rmvZyeMGzl8mdEX5gY69d6a6bHWmiPevwqFw+tQavhK0EYMaSg3/KD24cWqeQv1EWsqDQ==",
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-6.1.1.tgz",
+      "integrity": "sha512-M+cKwofFlHa5VpTWub7GLg5RLcunYIcLqtY5pKcls/u7xaAb8FrXZ520qY8rkpYy5xw90tYCyMO0MP5ggzR3Sw==",
       "dependencies": {
         "detect-libc": "^1.0.3",
         "expand-template": "^2.0.3",
@@ -2481,15 +2481,14 @@
         "minimist": "^1.2.3",
         "mkdirp-classic": "^0.5.3",
         "napi-build-utils": "^1.0.1",
-        "node-abi": "^2.7.0",
+        "node-abi": "^2.21.0",
         "noop-logger": "^0.1.1",
         "npmlog": "^4.0.1",
         "pump": "^3.0.0",
         "rc": "^1.2.7",
         "simple-get": "^3.0.3",
         "tar-fs": "^2.0.0",
-        "tunnel-agent": "^0.6.0",
-        "which-pm-runs": "^1.0.0"
+        "tunnel-agent": "^0.6.0"
       },
       "bin": {
         "prebuild-install": "bin.js"
@@ -2815,15 +2814,15 @@
       "integrity": "sha512-JvdAWfbXeIGaZ9cILp38HntZSFSo3mWg6xGcJJsd+d4aRMOqauag1C63dJfDw7OaMYwEbHMOxEZ1lqVRYP2OAw=="
     },
     "node_modules/sharp": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.28.0.tgz",
-      "integrity": "sha512-kGTaWLNMCkLYxkH2Pv7s+5LQBnWQ4mRKXs1XD19AWOxShWvU8b78qaWqTR/4ryNcPORO+qBoBnFF/Lzda5HgkQ==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.28.1.tgz",
+      "integrity": "sha512-4mCGMEN4ntaVuFGwHx7FvkJQkIgbI+S+F9a3bI7ugdvKjPr4sF7/ibvlRKhJyzhoQi+ODM+XYY1de8xs7MHbfA==",
       "hasInstallScript": true,
       "dependencies": {
         "color": "^3.1.3",
         "detect-libc": "^1.0.3",
         "node-addon-api": "^3.1.0",
-        "prebuild-install": "^6.0.1",
+        "prebuild-install": "^6.1.1",
         "semver": "^7.3.5",
         "simple-get": "^3.1.0",
         "tar-fs": "^2.1.1",
@@ -3496,11 +3495,6 @@
       "engines": {
         "node": ">= 8"
       }
-    },
-    "node_modules/which-pm-runs": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/which-pm-runs/-/which-pm-runs-1.0.0.tgz",
-      "integrity": "sha1-Zws6+8VS4LVd9rd4DKdGFfI60cs="
     },
     "node_modules/wide-align": {
       "version": "1.1.3",
@@ -5557,9 +5551,9 @@
       }
     },
     "prebuild-install": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-6.0.1.tgz",
-      "integrity": "sha512-7GOJrLuow8yeiyv75rmvZyeMGzl8mdEX5gY69d6a6bHWmiPevwqFw+tQavhK0EYMaSg3/KD24cWqeQv1EWsqDQ==",
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-6.1.1.tgz",
+      "integrity": "sha512-M+cKwofFlHa5VpTWub7GLg5RLcunYIcLqtY5pKcls/u7xaAb8FrXZ520qY8rkpYy5xw90tYCyMO0MP5ggzR3Sw==",
       "requires": {
         "detect-libc": "^1.0.3",
         "expand-template": "^2.0.3",
@@ -5567,15 +5561,14 @@
         "minimist": "^1.2.3",
         "mkdirp-classic": "^0.5.3",
         "napi-build-utils": "^1.0.1",
-        "node-abi": "^2.7.0",
+        "node-abi": "^2.21.0",
         "noop-logger": "^0.1.1",
         "npmlog": "^4.0.1",
         "pump": "^3.0.0",
         "rc": "^1.2.7",
         "simple-get": "^3.0.3",
         "tar-fs": "^2.0.0",
-        "tunnel-agent": "^0.6.0",
-        "which-pm-runs": "^1.0.0"
+        "tunnel-agent": "^0.6.0"
       }
     },
     "prepend-http": {
@@ -5835,14 +5828,14 @@
       "integrity": "sha512-JvdAWfbXeIGaZ9cILp38HntZSFSo3mWg6xGcJJsd+d4aRMOqauag1C63dJfDw7OaMYwEbHMOxEZ1lqVRYP2OAw=="
     },
     "sharp": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.28.0.tgz",
-      "integrity": "sha512-kGTaWLNMCkLYxkH2Pv7s+5LQBnWQ4mRKXs1XD19AWOxShWvU8b78qaWqTR/4ryNcPORO+qBoBnFF/Lzda5HgkQ==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.28.1.tgz",
+      "integrity": "sha512-4mCGMEN4ntaVuFGwHx7FvkJQkIgbI+S+F9a3bI7ugdvKjPr4sF7/ibvlRKhJyzhoQi+ODM+XYY1de8xs7MHbfA==",
       "requires": {
         "color": "^3.1.3",
         "detect-libc": "^1.0.3",
         "node-addon-api": "^3.1.0",
-        "prebuild-install": "^6.0.1",
+        "prebuild-install": "^6.1.1",
         "semver": "^7.3.5",
         "simple-get": "^3.1.0",
         "tar-fs": "^2.1.1",
@@ -6339,11 +6332,6 @@
       "requires": {
         "isexe": "^2.0.0"
       }
-    },
-    "which-pm-runs": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/which-pm-runs/-/which-pm-runs-1.0.0.tgz",
-      "integrity": "sha1-Zws6+8VS4LVd9rd4DKdGFfI60cs="
     },
     "wide-align": {
       "version": "1.1.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -45,7 +45,7 @@
         "@types/superagent": "^4.1.10",
         "cross-env": "^7.0.3",
         "ts-node": "^9.1.1",
-        "typescript": "^4.2.3"
+        "typescript": "^4.2.4"
       },
       "engines": {
         "node": ">=12.0.0"
@@ -3358,9 +3358,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "4.2.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.2.3.tgz",
-      "integrity": "sha512-qOcYwxaByStAWrBf4x0fibwZvMRG+r4cQoTjbPtUlrWjBHbmCAww1i448U0GJ+3cNNEtebDteo/cHOR3xJ4wEw==",
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.2.4.tgz",
+      "integrity": "sha512-V+evlYHZnQkaz8TRBuxTA92yZBPotr5H+WhQ7bD3hZUndx5tGOa1fuCgeSjxAzM1RiN5IzvadIXTVefuuwZCRg==",
       "dev": true,
       "bin": {
         "tsc": "bin/tsc",
@@ -6236,9 +6236,9 @@
       }
     },
     "typescript": {
-      "version": "4.2.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.2.3.tgz",
-      "integrity": "sha512-qOcYwxaByStAWrBf4x0fibwZvMRG+r4cQoTjbPtUlrWjBHbmCAww1i448U0GJ+3cNNEtebDteo/cHOR3xJ4wEw==",
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.2.4.tgz",
+      "integrity": "sha512-V+evlYHZnQkaz8TRBuxTA92yZBPotr5H+WhQ7bD3hZUndx5tGOa1fuCgeSjxAzM1RiN5IzvadIXTVefuuwZCRg==",
       "dev": true
     },
     "uid-safe": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
         "moment": "^2.29.1",
         "morgan": "^1.10.0",
         "node-cache": "^5.1.2",
-        "nodemailer": "^6.5.0",
+        "nodemailer": "^6.6.0",
         "nodemon": "^2.0.7",
         "object-assign-deep": "^0.4.0",
         "pg": "^8.6.0",
@@ -2157,9 +2157,9 @@
       }
     },
     "node_modules/nodemailer": {
-      "version": "6.5.0",
-      "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-6.5.0.tgz",
-      "integrity": "sha512-Tm4RPrrIZbnqDKAvX+/4M+zovEReiKlEXWDzG4iwtpL9X34MJY+D5LnQPH/+eghe8DLlAVshHAJZAZWBGhkguw==",
+      "version": "6.6.0",
+      "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-6.6.0.tgz",
+      "integrity": "sha512-ikSMDU1nZqpo2WUPE0wTTw/NGGImTkwpJKDIFPZT+YvvR9Sj+ze5wzu95JHkBMglQLoG2ITxU21WukCC/XsFkg==",
       "engines": {
         "node": ">=6.0.0"
       }
@@ -5319,9 +5319,9 @@
       }
     },
     "nodemailer": {
-      "version": "6.5.0",
-      "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-6.5.0.tgz",
-      "integrity": "sha512-Tm4RPrrIZbnqDKAvX+/4M+zovEReiKlEXWDzG4iwtpL9X34MJY+D5LnQPH/+eghe8DLlAVshHAJZAZWBGhkguw=="
+      "version": "6.6.0",
+      "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-6.6.0.tgz",
+      "integrity": "sha512-ikSMDU1nZqpo2WUPE0wTTw/NGGImTkwpJKDIFPZT+YvvR9Sj+ze5wzu95JHkBMglQLoG2ITxU21WukCC/XsFkg=="
     },
     "nodemon": {
       "version": "2.0.7",

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,7 @@
         "nodemailer": "^6.5.0",
         "nodemon": "^2.0.7",
         "object-assign-deep": "^0.4.0",
-        "pg": "^8.5.1",
+        "pg": "^8.6.0",
         "request": "^2.88.2",
         "rotating-file-stream": "^2.1.5",
         "sharp": "^0.28.1",
@@ -2365,26 +2365,34 @@
       "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns="
     },
     "node_modules/pg": {
-      "version": "8.5.1",
-      "resolved": "https://registry.npmjs.org/pg/-/pg-8.5.1.tgz",
-      "integrity": "sha512-9wm3yX9lCfjvA98ybCyw2pADUivyNWT/yIP4ZcDVpMN0og70BUWYEGXPCTAQdGTAqnytfRADb7NERrY1qxhIqw==",
+      "version": "8.6.0",
+      "resolved": "https://registry.npmjs.org/pg/-/pg-8.6.0.tgz",
+      "integrity": "sha512-qNS9u61lqljTDFvmk/N66EeGq3n6Ujzj0FFyNMGQr6XuEv4tgNTXvJQTfJdcvGit5p5/DWPu+wj920hAJFI+QQ==",
       "dependencies": {
         "buffer-writer": "2.0.0",
         "packet-reader": "1.0.0",
-        "pg-connection-string": "^2.4.0",
-        "pg-pool": "^3.2.2",
-        "pg-protocol": "^1.4.0",
+        "pg-connection-string": "^2.5.0",
+        "pg-pool": "^3.3.0",
+        "pg-protocol": "^1.5.0",
         "pg-types": "^2.1.0",
         "pgpass": "1.x"
       },
       "engines": {
         "node": ">= 8.0.0"
+      },
+      "peerDependencies": {
+        "pg-native": ">=2.0.0"
+      },
+      "peerDependenciesMeta": {
+        "pg-native": {
+          "optional": true
+        }
       }
     },
     "node_modules/pg-connection-string": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-2.4.0.tgz",
-      "integrity": "sha512-3iBXuv7XKvxeMrIgym7njT+HlZkwZqqGX4Bu9cci8xHZNT+Um1gWKqCsAzcC0d95rcKMU5WBg6YRUcHyV0HZKQ=="
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-2.5.0.tgz",
+      "integrity": "sha512-r5o/V/ORTA6TmUnyWZR9nCj1klXCO2CEKNRlVuJptZe85QuhFayC7WeMic7ndayT5IRIR0S0xFxFi2ousartlQ=="
     },
     "node_modules/pg-int8": {
       "version": "1.0.1",
@@ -2395,14 +2403,17 @@
       }
     },
     "node_modules/pg-pool": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/pg-pool/-/pg-pool-3.2.2.tgz",
-      "integrity": "sha512-ORJoFxAlmmros8igi608iVEbQNNZlp89diFVx6yV5v+ehmpMY9sK6QgpmgoXbmkNaBAx8cOOZh9g80kJv1ooyA=="
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/pg-pool/-/pg-pool-3.3.0.tgz",
+      "integrity": "sha512-0O5huCql8/D6PIRFAlmccjphLYWC+JIzvUhSzXSpGaf+tjTZc4nn+Lr7mLXBbFJfvwbP0ywDv73EiaBsxn7zdg==",
+      "peerDependencies": {
+        "pg": ">=8.0"
+      }
     },
     "node_modules/pg-protocol": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/pg-protocol/-/pg-protocol-1.4.0.tgz",
-      "integrity": "sha512-El+aXWcwG/8wuFICMQjM5ZSAm6OWiJicFdNYo+VY3QP+8vI4SvLIWVe51PppTzMhikUJR+PsyIFKqfdXPz/yxA=="
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/pg-protocol/-/pg-protocol-1.5.0.tgz",
+      "integrity": "sha512-muRttij7H8TqRNu/DxrAJQITO4Ac7RmX3Klyr/9mJEOBeIpgnF8f9jAfRz5d3XwQZl5qBjF9gLsUtMPJE0vezQ=="
     },
     "node_modules/pg-types": {
       "version": "2.2.0",
@@ -5469,23 +5480,23 @@
       "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns="
     },
     "pg": {
-      "version": "8.5.1",
-      "resolved": "https://registry.npmjs.org/pg/-/pg-8.5.1.tgz",
-      "integrity": "sha512-9wm3yX9lCfjvA98ybCyw2pADUivyNWT/yIP4ZcDVpMN0og70BUWYEGXPCTAQdGTAqnytfRADb7NERrY1qxhIqw==",
+      "version": "8.6.0",
+      "resolved": "https://registry.npmjs.org/pg/-/pg-8.6.0.tgz",
+      "integrity": "sha512-qNS9u61lqljTDFvmk/N66EeGq3n6Ujzj0FFyNMGQr6XuEv4tgNTXvJQTfJdcvGit5p5/DWPu+wj920hAJFI+QQ==",
       "requires": {
         "buffer-writer": "2.0.0",
         "packet-reader": "1.0.0",
-        "pg-connection-string": "^2.4.0",
-        "pg-pool": "^3.2.2",
-        "pg-protocol": "^1.4.0",
+        "pg-connection-string": "^2.5.0",
+        "pg-pool": "^3.3.0",
+        "pg-protocol": "^1.5.0",
         "pg-types": "^2.1.0",
         "pgpass": "1.x"
       }
     },
     "pg-connection-string": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-2.4.0.tgz",
-      "integrity": "sha512-3iBXuv7XKvxeMrIgym7njT+HlZkwZqqGX4Bu9cci8xHZNT+Um1gWKqCsAzcC0d95rcKMU5WBg6YRUcHyV0HZKQ=="
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-2.5.0.tgz",
+      "integrity": "sha512-r5o/V/ORTA6TmUnyWZR9nCj1klXCO2CEKNRlVuJptZe85QuhFayC7WeMic7ndayT5IRIR0S0xFxFi2ousartlQ=="
     },
     "pg-int8": {
       "version": "1.0.1",
@@ -5493,14 +5504,15 @@
       "integrity": "sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw=="
     },
     "pg-pool": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/pg-pool/-/pg-pool-3.2.2.tgz",
-      "integrity": "sha512-ORJoFxAlmmros8igi608iVEbQNNZlp89diFVx6yV5v+ehmpMY9sK6QgpmgoXbmkNaBAx8cOOZh9g80kJv1ooyA=="
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/pg-pool/-/pg-pool-3.3.0.tgz",
+      "integrity": "sha512-0O5huCql8/D6PIRFAlmccjphLYWC+JIzvUhSzXSpGaf+tjTZc4nn+Lr7mLXBbFJfvwbP0ywDv73EiaBsxn7zdg==",
+      "requires": {}
     },
     "pg-protocol": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/pg-protocol/-/pg-protocol-1.4.0.tgz",
-      "integrity": "sha512-El+aXWcwG/8wuFICMQjM5ZSAm6OWiJicFdNYo+VY3QP+8vI4SvLIWVe51PppTzMhikUJR+PsyIFKqfdXPz/yxA=="
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/pg-protocol/-/pg-protocol-1.5.0.tgz",
+      "integrity": "sha512-muRttij7H8TqRNu/DxrAJQITO4Ac7RmX3Klyr/9mJEOBeIpgnF8f9jAfRz5d3XwQZl5qBjF9gLsUtMPJE0vezQ=="
     },
     "pg-types": {
       "version": "2.2.0",

--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
     "@types/object-assign-deep": "^0.4.0",
     "@types/pg": "^7.14.11",
     "@types/request": "^2.48.5",
-    "@types/sharp": "^0.27.3",
+    "@types/sharp": "^0.28.0",
     "@types/superagent": "^4.1.10",
     "cross-env": "^7.0.3",
     "ts-node": "^9.1.1",

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "moment": "^2.29.1",
     "morgan": "^1.10.0",
     "node-cache": "^5.1.2",
-    "nodemailer": "^6.5.0",
+    "nodemailer": "^6.6.0",
     "nodemon": "^2.0.7",
     "object-assign-deep": "^0.4.0",
     "pg": "^8.6.0",

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "pg": "^8.5.1",
     "request": "^2.88.2",
     "rotating-file-stream": "^2.1.5",
-    "sharp": "^0.28.0",
+    "sharp": "^0.28.1",
     "superagent": "^6.1.0",
     "uuid": "^8.3.2"
   },

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "nodemailer": "^6.5.0",
     "nodemon": "^2.0.7",
     "object-assign-deep": "^0.4.0",
-    "pg": "^8.5.1",
+    "pg": "^8.6.0",
     "request": "^2.88.2",
     "rotating-file-stream": "^2.1.5",
     "sharp": "^0.28.1",

--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     "@types/superagent": "^4.1.10",
     "cross-env": "^7.0.3",
     "ts-node": "^9.1.1",
-    "typescript": "^4.2.3"
+    "typescript": "^4.2.4"
   },
   "nodemonConfig": {
     "watch": [


### PR DESCRIPTION
Additional changes:
* GitHub Actions now uses Node.js v12 and v14 when building the project.

Updated dependencies:
* `sharp`
* `@types/sharp`
* `pg`
* `typescript`
* `nodemailer`